### PR TITLE
Add custom RequestTracker 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+.idea
+*.iml

--- a/lib/appinsights/middlewares.rb
+++ b/lib/appinsights/middlewares.rb
@@ -1,4 +1,5 @@
 require_relative 'middlewares/exception_handling'
+require_relative 'middlewares/track_request'
 
 module AppInsights
   class Middlewares

--- a/lib/appinsights/middlewares/track_request.rb
+++ b/lib/appinsights/middlewares/track_request.rb
@@ -2,15 +2,15 @@ require 'application_insights'
 
 module AppInsights
   class TrackRequest
-    def initialize(app, instrumentation_key, ignore_prefixes = [], buffer_size = 500, send_interval = 60)
+    def initialize(app, instrumentation_key, prefixes_to_ignore = [], buffer_size = 500, send_interval = 60)
       @app = app
-      @ignore_prefixes = ignore_prefixes
+      @prefixes_to_ignore = prefixes_to_ignore
       @track_request = ApplicationInsights::Rack::TrackRequest.new(app, instrumentation_key, buffer_size, send_interval)
     end
 
     def call(env)
       path_info = env['PATH_INFO']
-      if @ignore_prefixes.any? { |prefix| path_info.start_with?(prefix) }
+      if @prefixes_to_ignore.any? { |prefix| path_info.start_with?(prefix) }
         @app.call env
       else
         @track_request.call env

--- a/lib/appinsights/middlewares/track_request.rb
+++ b/lib/appinsights/middlewares/track_request.rb
@@ -1,0 +1,20 @@
+require 'application_insights'
+
+module AppInsights
+  class TrackRequest
+    def initialize(app, instrumentation_key, ignore_prefixes = [], buffer_size = 500, send_interval = 60)
+      @app = app
+      @ignore_prefixes = ignore_prefixes
+      @track_request = ApplicationInsights::Rack::TrackRequest.new(app, instrumentation_key, buffer_size, send_interval)
+    end
+
+    def call(env)
+      path_info = env['PATH_INFO']
+      if @ignore_prefixes.any? { |prefix| path_info.starts_with?(prefix) }
+        @app.call env
+      else
+        @track_request.call env
+      end
+    end
+  end
+end

--- a/lib/appinsights/middlewares/track_request.rb
+++ b/lib/appinsights/middlewares/track_request.rb
@@ -10,7 +10,7 @@ module AppInsights
 
     def call(env)
       path_info = env['PATH_INFO']
-      if @ignore_prefixes.any? { |prefix| path_info.starts_with?(prefix) }
+      if @ignore_prefixes.any? { |prefix| path_info.start_with?(prefix) }
         @app.call env
       else
         @track_request.call env

--- a/lib/appinsights/version.rb
+++ b/lib/appinsights/version.rb
@@ -1,3 +1,3 @@
 module AppInsights
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end

--- a/test/mock/mock_app.rb
+++ b/test/mock/mock_app.rb
@@ -1,8 +1,13 @@
 class MockApp
-  attr_reader :middlewares
+  attr_reader :middlewares, :callcount
 
   def initialize
     @middlewares = []
+    @callcount = 0
+  end
+
+  def call _env
+    @callcount += 1
   end
 
   def use(middleware, *params, &block)

--- a/test/track_request_test.rb
+++ b/test/track_request_test.rb
@@ -1,0 +1,29 @@
+require_relative 'helper'
+require_relative 'mock/mock_app'
+require 'application_insights'
+
+describe AppInsights::TrackRequest do
+  before do
+    @app = MockApp.new
+  end
+
+  it 'just calls app when ignored' do
+    tracker = AppInsights::TrackRequest.new @app, '', ['/ignored']
+    tracker.call({'PATH_INFO' => '/ignored'})
+    assert_equal 1, @app.callcount
+  end
+
+  it 'calls tracker when not ignored' do
+    module ApplicationInsights
+      module Rack
+        class TrackRequest
+          def call _env
+          end
+        end
+      end
+    end
+    tracker = AppInsights::TrackRequest.new @app, '', ['/ignored']
+    tracker.call({'PATH_INFO' => '/real'})
+    assert_equal 0, @app.callcount
+  end
+end


### PR DESCRIPTION
that supports ignore prefixes so that applications can avoid sending ping 
requests to Microsoft AppInsights