### PR TITLE
[P4-2069] Disable appinsights through environment variable

### DIFF
--- a/lib/appinsights.rb
+++ b/lib/appinsights.rb
@@ -1,3 +1,5 @@
+return if ENV.fetch('APPINSIGHTS_ENABLED', 'true') == 'false'
+
 require 'logger'
 require_relative 'appinsights/errors'
 require_relative 'appinsights/context'


### PR DESCRIPTION
### What

Adds ability to disable the appinsights gem conditionally through an environment variable.

### Why

This is convenient for us because we can control it being on/off depending on the environment
